### PR TITLE
eraselinkA didn't erase stored data, only view

### DIFF
--- a/fieldsLinker.js
+++ b/fieldsLinker.js
@@ -482,7 +482,7 @@ let FL_Factory_Lists = null;
 		
 		$(factory).find(".FL-main .FL-left li").off("click").on("click", function (e) {
 			if (isDisabled) return;
-			eraseLinkA($(this).parent().data("name"));
+			eraseLinkA($(this).data("name"));
 			draw();
 		});
 	}
@@ -500,7 +500,7 @@ let FL_Factory_Lists = null;
 	
 	$(factory).find(".unlink").off("click").on("click", function (e) {
 		if (isDisabled) return;
-		eraseLinkA($(this).parent().data("name"));
+		eraseLinkA($(this).data("name"));
 		draw();
 	});
 	


### PR DESCRIPTION
Hello bonjour,

For the B list, it is called like that
eraseLinkB($(this).data("name"));

And for the A list, it was like this
eraseLinkA($(this).parent().data("name"));

Removing the parent() call makes the stored data correct.