### PR TITLE
fix mobileClickIt broken modeB, v0.91

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ the jquery plugin allows you to draw and save links between the 2 lists
 
 You can link on a one to one basis or on a one to many basis. Fields can be declared as mandatory the result reporting an error in case there are not filled.
 
+### v0.91
+
+Fix `mobileClickIt` option:
+
+- if set to `true`, will use mobile mode, regardless of touch screen mode.
+- fix crash modeB `null` value
+- if selected (clicked), use CSS to invert element as visual feedback.
+
 ### v0.90
 Canvas calulations fixes and other various fixes.
 

--- a/fieldsLinker.css
+++ b/fieldsLinker.css
@@ -35,6 +35,11 @@ tr td:not(:last-child)  {
     overflow: hidden;
 }
 
+.fieldsLinker li.selected {
+    -webkit-filter: invert(100%);
+    filter: invert(100%);    
+}
+
 .fieldsLinker li[data-mandatory='true'] {
     background-color: #D7504C;
     background: linear-gradient(#D7504C, #C12F2B);

--- a/fieldsLinker.js
+++ b/fieldsLinker.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-unused-vars */
 /*
 
-   https://github.com/PhilippeMarcMeyer/FieldsLinker v 0.90
+   https://github.com/PhilippeMarcMeyer/FieldsLinker v 0.91
+   v 0.91 : fix mobileClickIt if set, add selected css classes
    v 0.90 : Code beautified by flartet 
    v 0.89 : Corrected a bug that corrupted the links array of objects detected by flartet on github
    v 0.88 : New display mode : idea by Naveen nsirangu => show links between two "tables" linked by ids like a join in sql. instead of headers names, objects ar provided
@@ -201,7 +202,7 @@ let FL_Original_Factory_Lists = null;
         if (data.options.associationMode) {
             associationMode = data.options.associationMode;
         }
-        if (data.options.mobileClickIt && isTouchScreen) {
+        if (data.options.mobileClickIt) {
             mobileClickIt = true;
         }
     };
@@ -571,11 +572,14 @@ let FL_Original_Factory_Lists = null;
         }
 
         if (mobileClickIt) {
-            $(factory).find('.link').off('click').on('click', function (e) {
+            $(factory).find('.FL-left li').off('click').on('click', function (e) {
                 if (isDisabled) return;
+                const el = $(this);
+                $('.selected').removeClass('selected');
+                el.addClass('selected');                
                 move = {};
-                move.offsetA = $(this).parent().data('offset');
-                move.nameA = $(this).parent().data('name');
+                move.offsetA = el.data('offset');
+                move.nameA = el.data('name');
                 move.offsetB = -1;
                 move.nameB = -1;
             });
@@ -715,7 +719,8 @@ let FL_Original_Factory_Lists = null;
 
         if (mobileClickIt) {
             $(factory).find('.FL-right li').off('click').on('click', function (e) {
-                if (isDisabled) return;
+                $('.selected').removeClass('selected');
+                if (isDisabled || move === null) return;
                 move.offsetB = $(this).data('offset');
                 move.nameB = $(this).data('name');
                 var infos = JSON.parse(JSON.stringify(move));


### PR DESCRIPTION
Hi,

Thanks for the work on FieldsLinker! I want to use this in a small project of mine, but I have rather large lists. Scrolling is needed, and an `overflow-y: scroll` disables the dragging functionality. So, I wanted to leverage the use of `mobileClickIt` mode, without using a touchscreen device.

Take a look at the changes and pull if desired, or let me know what to change. 
Kind regards,
Wouter Groeneveld